### PR TITLE
fix: :bug: enabled `forceConsistentCasingInFileNames` to reduce issues when working with different OSes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "forceConsistentCasingInFileNames": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
# PR: Enable `forceConsistentCasingInFileNames` Option

## Change Description

Enabled the `forceConsistentCasingInFileNames` option in TypeScript configuration to ensure filename case consistency.

## Rationale

This configuration helps teams reduce issues when developing across different operating systems. Since Windows is case-insensitive for filenames while macOS and Linux are case-sensitive, this setting catches potential import errors.

## Technical Details

Added the following to tsconfig.json:
```json
"forceConsistentCasingInFileNames": true
```

This configuration requires that files are referenced with exactly the same casing as they exist in the file system, improving code portability and stability.